### PR TITLE
 #40 -  add specific capability for seeing this report

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -62,7 +62,9 @@ jobs:
 
       - name: Install Moodle
         # Need explicit IP to stop mysql client fail on attempt to use unix socket.
-        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        run: |
+          moodle-plugin-ci add-plugin --branch MOODLE_402_STABLE catalyst/moodle-gradingform_rubric_ranges
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
         env:
           DB: ${{ matrix.database }}
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}

--- a/btec.php
+++ b/btec.php
@@ -40,7 +40,7 @@ $data['modid'] = required_param('modid', PARAM_INT); // CM ID.
 
 $data = init($data);
 
-require_capability('mod/assign:grade', $data['context']);
+require_capability('report/advancedgrading:view', $data['context']);
 
 $btec = new btec();
 $data['dbrecords'] = $btec->get_data($data['cm']);

--- a/db/access.php
+++ b/db/access.php
@@ -15,20 +15,25 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Lang strings.
+ * List of capabilities.
  *
- * Language strings to be used by report/rubrics
- *
- * @package    report_advancedgrading
- * @copyright  2022 Marcus Green
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package report_advancedgrading
+ * @author Cristian Martinez
+ * @copyright 2025 Universitat Rovira i Virgili (https://www.urv.cat)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2025012100;  // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires  = 2022040100;  // Moodle 4.0.
-$plugin->release   = '1.01';
-$plugin->supported = [400, 405];
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->component = 'report_advancedgrading';  // Full name of the plugin (used for diagnostics).
+$capabilities = [
+    'report/advancedgrading:view' => [
+        'riskbitmask' => RISK_PERSONAL,
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW
+        ],
+    ],
+];

--- a/guide.php
+++ b/guide.php
@@ -38,7 +38,7 @@ $data['grademethod'] = 'guide';
 $data['modid'] = required_param('modid', PARAM_INT); // CM ID.
 $data = init($data);
 
-require_capability('mod/assign:grade', $data['context']);
+require_capability('report/advancedgrading:view', $data['context']);
 
 $guide = new guide();
 $data['dbrecords'] = $guide->get_data($data['assign'], $data['cm']);

--- a/lang/en/report_advancedgrading.php
+++ b/lang/en/report_advancedgrading.php
@@ -24,6 +24,7 @@
  */
 
 $string['pluginname'] = 'Advanced Grading report';
+$string['advancedgrading:view'] = 'Allow the user to see the rubric detail';
 $string['btecgrades'] = 'BTEC breakdown report';
 $string['rubricgrades'] = 'Rubric breakdown report';
 $string['guidegrades'] = 'Marking guide breakdown report';

--- a/lib.php
+++ b/lib.php
@@ -27,6 +27,8 @@
 defined('MOODLE_INTERNAL') || die;
 
 require_once($CFG->dirroot.'/grade/grading/lib.php');
+require_once($CFG->dirroot . '/report/advancedgrading/locallib.php');
+
 global $PAGE;
 /**
  * Add an item to the dropdown when viewing the assignment
@@ -36,8 +38,12 @@ global $PAGE;
  * @return void
  */
 function report_advancedgrading_extend_navigation_module(navigation_node $navigation, cm_info $cm) {
-    $context = \context_module::instance($cm->id);
-    if ($cm->modname == 'assign' && has_capability('moodle/grade:edit', $context)) {
+    $context = $cm->context;
+    $assignid = $cm->instance;
+
+    if ($cm->modname == 'assign' &&
+            has_capability('report/advancedgrading:view', $context) &&
+            !empty(get_grading_definition($assignid))) {
         $gradingmanager = get_grading_manager($context, 'mod_assign', 'submissions');
         switch ($gradingmanager->get_active_method()) {
             case 'rubric_ranges':

--- a/locallib.php
+++ b/locallib.php
@@ -36,16 +36,16 @@ defined('MOODLE_INTERNAL') || die;
  * Get the structure of this grading definition
  *
  * @param int $assignid
- * @return \stdClass
+ * @return false|\stdClass
  */
-function get_grading_definition(int $assignid): \stdClass {
+function get_grading_definition(int $assignid) {
     global $DB;
     $sql = "SELECT gdef.id AS definitionid, ga.activemethod, gdef.name AS definition
               FROM {assign} assign
               JOIN {course_modules} cm ON cm.instance = assign.id
               JOIN {context} ctx ON ctx.instanceid = cm.id
               JOIN {grading_areas} ga ON ctx.id=ga.contextid
-              JOIN {grading_definitions} gdef ON ga.id = gdef.areaid
+              JOIN {grading_definitions} gdef ON (ga.id = gdef.areaid AND ga.activemethod = gdef.method)
              WHERE assign.id = :assignid";
     $definition = $DB->get_record_sql($sql, ['assignid' => $assignid]);
     return $definition;

--- a/rubref.php
+++ b/rubref.php
@@ -40,7 +40,7 @@ $data['grademethod'] = 'rubref';
 $data['modid'] = required_param('modid', PARAM_INT); // CM ID.
 
 $data = init($data);
-require_capability('mod/assign:grade', $data['context']);
+require_capability('report/advancedgrading:view', $data['context']);
 
 $rubref = new rubref();
 $data['dbrecords'] = $rubref->get_data($data['assign'], $data['cm']);

--- a/rubric.php
+++ b/rubric.php
@@ -40,7 +40,7 @@ $data['grademethod'] = 'rubric';
 $data['modid'] = required_param('modid', PARAM_INT); // CM ID.
 
 $data = init($data);
-require_capability('mod/assign:grade', $data['context']);
+require_capability('report/advancedgrading:view', $data['context']);
 
 $rubric = new rubric();
 $data['dbrecords'] = $rubric->get_data($data['assign'], $data['cm']);

--- a/rubric_ranges.php
+++ b/rubric_ranges.php
@@ -40,7 +40,7 @@ $data['grademethod'] = 'rubric_ranges';
 $data['modid'] = required_param('modid', PARAM_INT); // CM ID.
 
 $data = init($data);
-require_capability('mod/assign:grade', $data['context']);
+require_capability('report/advancedgrading:view', $data['context']);
 
 $rubricranges = new rubric_ranges();
 $data['dbrecords'] = $rubricranges->get_data($data['assign'], $data['cm']);


### PR DESCRIPTION
Here it is: this is the PR we have built for adding a specific capability to seeing this report.

As explained in #40: this allows external users to the instutions with a specific role to have a look at how things were done on any course, without requiring the capability of editing grades (as it is right now).

Thanks for this great plugin.

Let us know if we can do anything else.

Note: I am publishing the work, however, a colleague of mine is who did this work.