### PR TITLE
Adding missing lang string eventreportviewed

### DIFF
--- a/lang/en/report_advancedgrading.php
+++ b/lang/en/report_advancedgrading.php
@@ -32,6 +32,7 @@ $string['csvdownload_help'] = 'Download a comma Separated values version of the 
 $string['definition'] = 'Definition';
 $string['enable_javascriptlayout'] = 'Enable javascript layout';
 $string['enable_javascriptlayout_desc'] = 'Adds paging and sorting to the table layout, may add a performance overhead';
+$string['eventreportviewed'] = 'Advanced Grading report viewed';
 $string['exceldownload'] = 'Excel download';
 $string['exceldownload_help'] = 'Download an Excel spreadsheet format (xlsx) version of the table';
 $string['feedback'] = 'Feedback';


### PR DESCRIPTION

I've following error while running unit tests, it's a simple lang string to fix.

```
Invalid get_string() identifier: 'eventreportviewed' or component 'report_advancedgrading'. 
Perhaps you are missing $string['eventreportviewed'] = '';
line 356 of /lib/classes/string_manager_standard.php: call to debugging()
* line 7045 of /lib/moodlelib.php: call to core_string_manager_standard->get_string()
* line 52 of /report/advancedgrading/classes/event/report_viewed.php: call to get_string()
* line 57 of /lib/tests/event/plugin_checks_test.php: call to port_advancedgrading\event\report_viewed::get_name()
```
