### PR TITLE
Add marker and marking workflow columns

### DIFF
--- a/classes/btec.php
+++ b/classes/btec.php
@@ -53,7 +53,7 @@ class btec {
                     $rows .= '<td>' . $student['grades'][$crikey]['definition'] .'</td>';
                     $rows .= '<td>' . $student['grades'][$crikey]['feedback'] . '</td>';
                 }
-                $rows .= get_summary_cells($student);
+                $rows .= get_summary_cells($data, $student);
                 $rows .= '</tr>';
             }
         }
@@ -81,7 +81,9 @@ class btec {
                                         marker.email AS graderemail,
                                         stu.id AS userid, stu.idnumber AS idnumber, stu.firstname, stu.lastname,
                                         stu.username AS username, gin.timemodified AS modified,ag.id, ag.grade,
-                                        assign_comment.commenttext as overallfeedback
+                                        assign_comment.commenttext as overallfeedback,
+                                        auf.workflowstate AS workflowstate, auf.allocatedmarker AS allocatedmarker,
+                                        amu.firstname AS markerfirstname, amu.lastname AS markerlastname
                                 FROM {course} crs
                                 JOIN {course_modules} cm ON crs.id = cm.course
                                 JOIN {assign} asg ON asg.id = cm.instance
@@ -94,6 +96,8 @@ class btec {
                                 JOIN {assignfeedback_comments} assign_comment on ag.id=assign_comment.grade
                                 JOIN {user} stu ON stu.id = ag.userid
                                 JOIN {user} marker ON marker.id = ag.grader
+                           LEFT JOIN {assign_user_flags} auf ON auf.assignment = asg.id AND auf.userid = stu.id
+                           LEFT JOIN {user} amu ON amu.id = auf.allocatedmarker
                                 JOIN {gradingform_btec_fillings} gbf ON (gbf.instanceid = gin.id)
                                  AND (gbf.criterionid = criteria.id)
                                WHERE cm.id = :cmid AND gin.status = :instancestatus

--- a/classes/guide.php
+++ b/classes/guide.php
@@ -57,7 +57,7 @@ class guide {
                         $rows .= '<td></td>';
                     }
                 }
-                $rows .= get_summary_cells($student);
+                $rows .= get_summary_cells($data, $student);
                 $rows .= '</tr>';
             }
 
@@ -90,7 +90,9 @@ class guide {
                         rubm.email AS graderemail,
                     stu.id AS userid, stu.idnumber AS idnumber, stu.firstname, stu.lastname,
                     stu.username, stu.email, ag.timemodified AS modified, ag.grade,
-                    assign_comment.commenttext as overallfeedback
+                    assign_comment.commenttext as overallfeedback,
+                    auf.workflowstate AS workflowstate, auf.allocatedmarker AS allocatedmarker,
+                    amu.firstname AS markerfirstname, amu.lastname AS markerlastname
             FROM {assign} asg
             JOIN {course_modules} cm ON cm.instance = asg.id
             JOIN {context} ctx ON ctx.instanceid = cm.id
@@ -102,6 +104,8 @@ class guide {
       LEFT  JOIN {assignfeedback_comments} assign_comment on assign_comment.grade = ag.id
             JOIN {user} stu ON stu.id = ag.userid
             JOIN {user} rubm ON rubm.id = ag.grader
+       LEFT JOIN {assign_user_flags} auf ON auf.assignment = asg.id AND auf.userid = stu.id
+       LEFT JOIN {user} amu ON amu.id = auf.allocatedmarker
             JOIN {gradingform_guide_fillings} fillings ON (fillings.instanceid = gin.id)
              AND (fillings.criterionid = criteria.id)
            WHERE cm.id = :assignid AND gin.status = :instancestatus

--- a/classes/rubref.php
+++ b/classes/rubref.php
@@ -53,7 +53,7 @@ class rubref {
                     $rows .= '<td>' . $student['grades'][$crikey]['definition'] .'</td>';
                     $rows .= '<td>' . $student['grades'][$crikey]['feedback'] . '</td>';
                 }
-                $rows .= get_summary_cells($student);
+                $rows .= get_summary_cells($data, $student);
                 $rows .= '</tr>';
             }
         }
@@ -85,7 +85,9 @@ class rubref {
                         rubm.firstname AS graderfirstname, rubm.lastname AS graderlastname,
                         rubm.email AS graderemail,
                         gin.timemodified AS modified,
-                        ctx.instanceid, ag.grade, asg.blindmarking, assign_comment.commenttext as overallfeedback
+                        ctx.instanceid, ag.grade, asg.blindmarking, assign_comment.commenttext as overallfeedback,
+                        auf.workflowstate AS workflowstate, auf.allocatedmarker AS allocatedmarker,
+                        amu.firstname AS markerfirstname, amu.lastname AS markerlastname
                     FROM {assign} asg
                     JOIN {course_modules} cm ON cm.instance = asg.id
                     JOIN {context} ctx ON ctx.instanceid = cm.id
@@ -98,6 +100,8 @@ class rubref {
                LEFT JOIN {assignfeedback_comments} assign_comment on assign_comment.grade = ag.id
                     JOIN {user} stu ON stu.id = ag.userid
                     JOIN {user} rubm ON rubm.id = ag.grader
+               LEFT JOIN {assign_user_flags} auf ON auf.assignment = asg.id AND auf.userid = stu.id
+               LEFT JOIN {user} amu ON amu.id = auf.allocatedmarker
                     JOIN {gradingform_rubref_fillings} grf ON (grf.instanceid = gin.id)
                      AND (grf.criterionid = criteria.id) AND (grf.levelid = level.id)
                 WHERE cm.id = :assignid AND gin.status = :instancestatus

--- a/classes/rubric.php
+++ b/classes/rubric.php
@@ -53,7 +53,7 @@ class rubric {
                     $rows .= '<td>' . $student['grades'][$crikey]['definition'] .'</td>';
                     $rows .= '<td>' . $student['grades'][$crikey]['feedback'] . '</td>';
                 }
-                $rows .= get_summary_cells($student);
+                $rows .= get_summary_cells($data, $student);
                 $rows .= '</tr>';
             }
         }
@@ -85,7 +85,9 @@ class rubric {
                         rubm.firstname AS graderfirstname, rubm.lastname AS graderlastname,
                         rubm.email AS graderemail,
                         ag.timemodified AS modified,
-                        ctx.instanceid, ag.grade, asg.blindmarking, assign_comment.commenttext as overallfeedback
+                        ctx.instanceid, ag.grade, asg.blindmarking, assign_comment.commenttext as overallfeedback,
+                        auf.workflowstate AS workflowstate, auf.allocatedmarker AS allocatedmarker,
+                        amu.firstname AS markerfirstname, amu.lastname AS markerlastname
                     FROM {assign} asg
                     JOIN {course_modules} cm ON cm.instance = asg.id
                     JOIN {context} ctx ON ctx.instanceid = cm.id
@@ -98,6 +100,8 @@ class rubric {
             LEFT  JOIN {assignfeedback_comments} assign_comment on assign_comment.grade = ag.id
                     JOIN {user} stu ON stu.id = ag.userid
                     JOIN {user} rubm ON rubm.id = ag.grader
+               LEFT JOIN {assign_user_flags} auf ON auf.assignment = asg.id AND auf.userid = stu.id
+               LEFT JOIN {user} amu ON amu.id = auf.allocatedmarker
                     JOIN {gradingform_rubric_fillings} grf ON (grf.instanceid = gin.id)
                     AND (grf.criterionid = criteria.id) AND (grf.levelid = level.id)
                 WHERE cm.id = :assignid AND gin.status = :instancestatus

--- a/classes/rubric_ranges.php
+++ b/classes/rubric_ranges.php
@@ -53,7 +53,7 @@ class rubric_ranges {
                     $rows .= '<td>' . $student['grades'][$crikey]['definition'] . '</td>';
                     $rows .= '<td>' . $student['grades'][$crikey]['feedback'] . '</td>';
                 }
-                $rows .= get_summary_cells($student);
+                $rows .= get_summary_cells($data, $student);
                 $rows .= '</tr>';
             }
         }
@@ -86,7 +86,9 @@ class rubric_ranges {
                         rubm.firstname AS graderfirstname, rubm.lastname AS graderlastname,
                         rubm.email AS graderemail,
                         ag.timemodified AS modified,
-                        ctx.instanceid, ag.grade, asg.blindmarking, assign_comment.commenttext as overallfeedback
+                        ctx.instanceid, ag.grade, asg.blindmarking, assign_comment.commenttext as overallfeedback,
+                        auf.workflowstate AS workflowstate, auf.allocatedmarker AS allocatedmarker,
+                        amu.firstname AS markerfirstname, amu.lastname AS markerlastname
                     FROM {assign} asg
                     JOIN {course_modules} cm ON cm.instance = asg.id
                     JOIN {context} ctx ON ctx.instanceid = cm.id
@@ -99,6 +101,8 @@ class rubric_ranges {
             LEFT  JOIN {assignfeedback_comments} assign_comment on assign_comment.grade = ag.id
                     JOIN {user} stu ON stu.id = ag.userid
                     JOIN {user} rubm ON rubm.id = ag.grader
+               LEFT JOIN {assign_user_flags} auf ON auf.assignment = asg.id AND auf.userid = stu.id
+               LEFT JOIN {user} amu ON amu.id = auf.allocatedmarker
                     JOIN {gradingform_rubric_ranges_f} grf ON (grf.instanceid = gin.id)
                     AND (grf.criterionid = criteria.id) AND (grf.levelid = level.id)
                 WHERE cm.id = :assignid AND gin.status = :instancestatus AND stu.deleted = 0

--- a/locallib.php
+++ b/locallib.php
@@ -182,6 +182,10 @@ function init(array $data): array {
     $data['context'] = \context_module::instance($data['cm']->id);
     $data['assign'] = new assign($data['context'], $data['cm'], $data['cm']->get_course());
 
+    $instance = $data['assign']->get_instance();
+    $data['showmarker'] = !empty($instance->markingworkflow) && !empty($instance->markingallocation);
+    $data['showworkflowstate'] = !empty($instance->markingworkflow);
+
     if ($data['grademethod'] == 'rubric_ranges') {
         $criteriatable = 'gradingform_' . $data['grademethod'] . '_c';
     } else {
@@ -192,8 +196,18 @@ function init(array $data): array {
     $data = header_fields($data, $data['criteriarecord'], $data['course'], $data['cm'], $data['gradingdefinition']);
     $data['definition'] = get_grading_definition($data['cm']->instance);
     $data['formaction'] = 'action='.$data['grademethod'] .'.php?id='.$data['courseid'].'&modid='.$data['modid'];
-    // Summary always has 4 columns.
-    $data['summaryspan'] = 4;
+    $extrasummary = ($data['showmarker'] ? 1 : 0) + ($data['showworkflowstate'] ? 1 : 0);
+    $data['summaryspan'] = 4 + $extrasummary;
+    $data['colcount'] += $extrasummary;
+    $data['summaryheader'] = '';
+    if ($data['showmarker']) {
+        $data['summaryheader'] .= '<th ' . $data['headerstyle'] . '><b>'
+            . get_string('marker', 'assign') . '</b></th>';
+    }
+    if ($data['showworkflowstate']) {
+        $data['summaryheader'] .= '<th ' . $data['headerstyle'] . '><b>'
+            . get_string('markingworkflowstate', 'assign') . '</b></th>';
+    }
     // TODO check if headerspanis actually used.
     $data['headerspan'] = $data['colcount'];
 
@@ -258,6 +272,8 @@ function get_grades(array $data, array $dbrecords): array {
             'grader' => gradedbydata($grade),
             'timegraded' => $grade->modified,
             'grade' => $formattedgrade,
+            'marker' => trim(($grade->markerfirstname ?? '') . ' ' . ($grade->markerlastname ?? '')),
+            'workflowstate' => $grade->workflowstate ?? '',
         ];
 
         foreach ($data['students'] as $student) {
@@ -332,11 +348,19 @@ function set_blindmarking(array $data, $assign, $cm): array {
  * @param mixed $student
  * @return string
  */
-function get_summary_cells($student): string {
+function get_summary_cells(array $data, $student): string {
     $cell = '<td>' . $student['gradeinfo']['overallfeedback'] . '</td>';
     $cell .= '<td>' . $student['gradeinfo']['grade'] . '</td>';
     $cell .= '<td>' . $student['gradeinfo']['grader'] . '</td>';
     $cell .= '<td>' . \userdate($student['gradeinfo']['timegraded'], "%d %b %Y %I:%M %p") . '</td>';
+    if (!empty($data['showmarker'])) {
+        $cell .= '<td>' . s($student['gradeinfo']['marker']) . '</td>';
+    }
+    if (!empty($data['showworkflowstate'])) {
+        $ws = $student['gradeinfo']['workflowstate'];
+        $label = $ws ? get_string('markingworkflowstate' . $ws, 'assign') : '';
+        $cell .= '<td>' . $label . '</td>';
+    }
     return $cell;
 }
 /**

--- a/templates/guide.mustache
+++ b/templates/guide.mustache
@@ -53,6 +53,7 @@ along with Moodle. If not, see
             <th {{{headerstyle}}} ><b>{{#str}}grade, report_advancedgrading{{/str}} </b></th>
             <th {{{headerstyle}}} ><b>{{#str}}gradedby, report_advancedgrading{{/str}}</b></th>
             <th {{{headerstyle}}} ><b>{{#str}}timegraded, report_advancedgrading {{/str}}</b></th>
+            {{{summaryheader}}}
          </tr>
     </thead>
     <tbody>

--- a/tests/behat/advancedgrading_guide_workflow.feature
+++ b/tests/behat/advancedgrading_guide_workflow.feature
@@ -1,0 +1,91 @@
+@report @report_advancedgrading @report_advancedgrading_guide_workflow @javascript
+
+Feature: Advancedgrading marking guide report shows allocated marker and marking workflow state
+  In order to monitor who is marking what and where each submission sits in the workflow
+  As an editing teacher viewing the marking guide breakdown report
+  Then the report shows the allocated marker and the localised marking workflow state
+
+  Background:
+    Given the following config values are set as admin:
+      | enable_javascriptlayout | 0 | report_advancedgrading |
+
+  Scenario: Allocate a marker, set workflow state, and verify the breakdown report.
+    Given the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | 1        | teacher1@example.com |
+      | teacher2 | Teacher   | 2        | teacher2@example.com |
+      | student1 | Student   | 1        | student1@example.com |
+    And the following "courses" exist:
+      | fullname | shortname | format |
+      | Course 1 | C1        | topics |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | teacher2 | C1     | editingteacher |
+      | student1 | C1     | student        |
+    And the following "activity" exists:
+      | activity                            | assign            |
+      | name                                | Test assignment 1 |
+      | course                              | C1                |
+      | section                             | 1                 |
+      | assignsubmission_file_enabled       | 0                 |
+      | assignsubmission_onlinetext_enabled | 1                 |
+      | attemptreopenmethod                 | manual            |
+      | assignfeedback_comments_enabled     | 1                 |
+      | markingworkflow                     | 1                 |
+      | markingallocation                   | 1                 |
+    And I am on the "Test assignment 1" "assign activity editing" page logged in as teacher1
+    And I set the following fields to these values:
+      | Grading method | Marking guide |
+    And I press "Save and return to course"
+    # Defining a marking guide
+    When I go to "Test assignment 1" advanced grading definition page
+    And I change window size to "large"
+    And I set the following fields to these values:
+      | Name        | Assignment 1 marking guide     |
+      | Description | Marking guide test description |
+    And I define the following marking guide:
+      | Criterion name    | Description for students         | Description for markers         | Maximum score |
+      | Guide criterion A | Guide A description for students | Guide A description for markers | 30            |
+      | Guide criterion B | Guide B description for students | Guide B description for markers | 30            |
+      | Guide criterion C | Guide C description for students | Guide C description for markers | 40            |
+    And I press "Save marking guide and make it ready"
+    And I log out
+    And I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I click on "Test assignment 1" "link"
+    And I click on "Add submission" "button"
+    And I set the field "Online text" to "First response"
+    And I click on "Save changes" "button"
+    And I log out
+    # teacher1 grades and allocates teacher2 as the marker
+    And I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I go to "Student 1" "Test assignment 1" activity advanced grading page
+    And I grade by filling the marking guide with:
+      | Guide criterion A | 25 | Very good |
+      | Guide criterion B | 20 |           |
+      | Guide criterion C | 35 | Nice!     |
+    And I set the field "Marking workflow state" to "In marking"
+    And I set the field "allocatedmarker" to "Teacher 2"
+    And I press "Save changes"
+    And I complete the advanced grading form with these values:
+      | Feedback comments | In general... work harder... |
+    And I am on the "Test assignment 1" "assign activity" page
+    And I navigate to "Marking guide breakdown report" in current page administration
+    And I wait until the page is ready
+    # The new marker and workflow columns and their values are visible
+    And I should see "Marker"
+    And I should see "Marking workflow state"
+    And I should see "Teacher 2"
+    And I should see "In marking"
+    And I should see "80.00"
+    # Move the workflow state on and confirm the column updates
+    When I go to "Student 1" "Test assignment 1" activity advanced grading page
+    And I set the field "Marking workflow state" to "Released"
+    And I press "Save changes"
+    And I am on the "Test assignment 1" "assign activity" page
+    And I navigate to "Marking guide breakdown report" in current page administration
+    And I wait until the page is ready
+    And I should see "Released"
+    And I should see "Teacher 2"

--- a/tests/behat/advancedgrading_rubric_workflow.feature
+++ b/tests/behat/advancedgrading_rubric_workflow.feature
@@ -1,0 +1,89 @@
+@report @report_advancedgrading @report_advancedgrading_rubric_workflow @javascript
+
+Feature: Advancedgrading rubric report shows allocated marker and marking workflow state
+  In order to monitor who is marking what and where each submission sits in the workflow
+  As an editing teacher viewing the rubric breakdown report
+  Then the report shows the allocated marker and the localised marking workflow state
+
+  Background:
+    Given the following config values are set as admin:
+      | enable_javascriptlayout | 0 | report_advancedgrading |
+
+  Scenario: Allocate a marker, set workflow state, and verify the breakdown report.
+    Given the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | 1        | teacher1@example.com |
+      | teacher2 | Teacher   | 2        | teacher2@example.com |
+      | student1 | Student   | 1        | student1@example.com |
+    And the following "courses" exist:
+      | fullname | shortname | format |
+      | Course 1 | C1        | topics |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | teacher2 | C1     | editingteacher |
+      | student1 | C1     | student        |
+    And the following "activity" exists:
+      | activity                            | assign            |
+      | name                                | Test assignment 1 |
+      | course                              | C1                |
+      | section                             | 1                 |
+      | assignsubmission_file_enabled       | 0                 |
+      | assignsubmission_onlinetext_enabled | 1                 |
+      | attemptreopenmethod                 | manual            |
+      | assignfeedback_comments_enabled     | 1                 |
+      | markingworkflow                     | 1                 |
+      | markingallocation                   | 1                 |
+    And I am on the "Test assignment 1" "assign activity editing" page logged in as teacher1
+    And I set the following fields to these values:
+      | Grading method | Rubric |
+    And I press "Save and return to course"
+    # Defining a rubric
+    When I go to "Test assignment 1" advanced grading definition page
+    And I change window size to "large"
+    And I set the following fields to these values:
+      | Name        | Assignment 1 rubric     |
+      | Description | Rubric test description |
+    And I define the following rubric:
+      | Criterion 1 | Good writing      | 10 | Excellent writing   | 30 |
+      | Criterion 2 | OK Punctuation    | 20 | Perfect Punctuation | 35 |
+      | Criterion 3 | Slightly original | 15 | Truly original      | 40 |
+    And I press "Save rubric and make it ready"
+    And I log out
+    And I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I click on "Test assignment 1" "link"
+    And I click on "Add submission" "button"
+    And I set the field "Online text" to "First response"
+    And I click on "Save changes" "button"
+    And I log out
+    # teacher1 grades and allocates teacher2 as the marker
+    And I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I go to "Student 1" "Test assignment 1" activity advanced grading page
+    And I grade by filling the rubric with:
+      | Criterion 1 | 10 | Nice       |
+      | Criterion 2 | 20 | Good       |
+      | Criterion 3 | 15 | Acceptable |
+    And I set the field "Marking workflow state" to "In marking"
+    And I set the field "allocatedmarker" to "Teacher 2"
+    And I press "Save changes"
+    And I complete the advanced grading form with these values:
+      | Feedback comments | In general... work harder... |
+    And I am on the "Test assignment 1" "assign activity" page
+    And I navigate to "Rubric breakdown report" in current page administration
+    And I wait until the page is ready
+    # The new marker and workflow columns and their values are visible
+    And I should see "Marker"
+    And I should see "Marking workflow state"
+    And I should see "Teacher 2"
+    And I should see "In marking"
+    # Move the workflow state on and confirm the column updates
+    When I go to "Student 1" "Test assignment 1" activity advanced grading page
+    And I set the field "Marking workflow state" to "Released"
+    And I press "Save changes"
+    And I am on the "Test assignment 1" "assign activity" page
+    And I navigate to "Rubric breakdown report" in current page administration
+    And I wait until the page is ready
+    And I should see "Released"
+    And I should see "Teacher 2"


### PR DESCRIPTION
Updated all reports to display and export marker and marking workflow status (if enabled).  Changes are in the same style as the original code, i.e., current standards or best practices may not have been followed. Added behat tests for core advanced grading types.