### PR TITLE
Respect blind marking in BTEC report

### DIFF
--- a/btec.php
+++ b/btec.php
@@ -43,7 +43,7 @@ $data = init($data);
 require_capability('report/advancedgrading:view', $data['context']);
 
 $btec = new btec();
-$data['dbrecords'] = $btec->get_data($data['cm']);
+$data['dbrecords'] = $btec->get_data($data['assign'], $data['cm']);
 
 $data = user_fields($data, $data['dbrecords']);
 if (isset($data['students'])) {

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,19 @@
 ### Version 1.05 Apr 2026
 Confirmed compatibility with Moodle 5.2.
 
+Blind marking is now actually applied to the BTEC report. btec::get_data()
+never called set_blindmarking(), so student identities (name, email,
+idnumber) were exposed on screen and in the Excel/CSV export even when the
+assignment used blind marking. The assign object is now passed in and the
+identities obscured, matching the rubric, guide, rubref and rubric_ranges
+methods. Added a PHPUnit test covering the blind/reveal paths (skipped when
+the third-party gradingform_btec plugin is not installed).
+
+NOTE: the Version 1.02 entry below stated this was fixed, but no such code
+ever reached btec.php - that credit (Juan Segarra / issue #19) was for the
+active grading instances change, not blind marking. BTEC blind marking had
+been broken since the method was first added.
+
 ### Version 1.04 Oct 2025
 Confirmed compatibility with Moodle 5.1.
 
@@ -19,6 +32,8 @@ Confirmed compatibility with Moodle 5.0
 
 Blind marking was not being applied when processing for a BTEC grading
 This was noticed during a scan using OpenAI 04-mini.
+(Correction: see Version 1.05 - this BTEC blind marking fix did not actually
+reach the code at the time and was only resolved in 1.05.)
 
 Thanks to Juan Segarra Montesinos for code to fix
 https://github.com/marcusgreen/moodle-report_advancedgrading/issues/19

--- a/classes/btec.php
+++ b/classes/btec.php
@@ -68,10 +68,11 @@ class btec {
     /**
      * Query the database for the student grades.
      *
+     * @param \assign $assign
      * @param \cm_info $cm
      * @return array
      */
-    public function get_data(\cm_info $cm): array {
+    public function get_data(\assign $assign, \cm_info $cm): array {
         global $DB;
         $sql = "SELECT gbf.id AS ggfid, crs.shortname AS course, asg.name AS assignment, asg.grade as gradeoutof, gd.name AS btec,
                                         criteria.shortname, criteria.description as definition, criteria.description , gbf.score,
@@ -100,6 +101,7 @@ class btec {
                                 criteria.shortname ASC";
 
         $data = $DB->get_records_sql($sql, ['cmid' => $cm->id, 'instancestatus' => \gradingform_instance::INSTANCE_STATUS_ACTIVE]);
+        $data = set_blindmarking($data, $assign, $cm);
         return $data;
     }
 }

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -263,6 +263,84 @@ final class locallib_test extends \advanced_testcase {
     }
 
     /**
+     * Check the BTEC report respects anonymous (blind) marking.
+     *
+     * The BTEC grading method had no fixture in the shared backup, and its
+     * get_data() previously did not call set_blindmarking(), so it leaked
+     * student identities. This restores a BTEC-graded assignment, enables
+     * blind marking, and confirms names are obscured then revealed.
+     *
+     * @covers ::btec->get_data
+     *
+     * @return void
+     */
+    public function test_btec(): void {
+        $this->resetAfterTest();
+        global $DB, $USER, $CFG;
+
+        if (core_component::get_plugin_directory('gradingform', 'btec') === null) {
+            $this->markTestSkipped('BTEC grading plugin not installed');
+        }
+
+        // Restore the BTEC activity backup into a fresh course.
+        $course = $this->getDataGenerator()->create_course();
+        $foldername = 'backup-btec';
+        $fp = get_file_packer('application/vnd.moodle.backup');
+        $tempdir = make_backup_temp_directory($foldername);
+        $fp->extract_to_pathname(
+            $CFG->dirroot . '/grade/grading/form/btec/tests/fixtures/backup_btec_grading.mbz',
+            $tempdir
+        );
+        $controller = new \restore_controller(
+            $foldername,
+            $course->id,
+            \backup::INTERACTIVE_NO,
+            \backup::MODE_GENERAL,
+            $USER->id,
+            \backup::TARGET_EXISTING_ADDING
+        );
+        $controller->execute_precheck();
+        $controller->execute_plan();
+
+        $assignrecord = $DB->get_record('assign', ['course' => $course->id], '*', MUST_EXIST);
+        // Enable blind marking on the restored assignment before building the assign object.
+        $DB->set_field('assign', 'blindmarking', 1, ['id' => $assignrecord->id]);
+
+        $cm = get_coursemodule_from_instance('assign', $assignrecord->id, $course->id);
+        $data['headerstyle'] = 'style="background-color:#D2D2D2;"';
+        $data['reportname'] = get_string('btecreportname', 'report_advancedgrading');
+        $data['grademethod'] = 'btec';
+        $data['modid'] = $cm->id;
+        $data['courseid'] = $course->id;
+        $data = init($data);
+
+        $this->assertTrue($data['assign']->is_blind_marking());
+
+        $btec = new btec();
+        $data['dbrecords'] = $btec->get_data($data['assign'], $data['cm']);
+        $this->assertNotEmpty($data['dbrecords']);
+
+        // The set_blindmarking() helper obscures the name fields but keeps the real
+        // userid, so fetch the real account to compare against.
+        $record = reset($data['dbrecords']);
+        $realuser = $DB->get_record('user', ['id' => $record->userid], '*', MUST_EXIST);
+        $participant = get_string('participant', 'report_advancedgrading');
+
+        // Confirm blind marking obscures the real name with the anonymous id.
+        $this->assertStringStartsWith($participant, $record->username);
+        $this->assertStringStartsWith($participant, $record->firstname);
+        $this->assertStringStartsWith($participant, $record->lastname);
+        $this->assertStringNotContainsString($realuser->username, $record->username);
+
+        // Reveal identities and confirm the real name then shows in the report.
+        $data['assign']->reveal_identities();
+        $data['dbrecords'] = $btec->get_data($data['assign'], $data['cm']);
+        $record = reset($data['dbrecords']);
+        $this->assertStringNotContainsString($participant, $record->username);
+        $this->assertEquals($realuser->username, $record->username);
+    }
+
+    /**
      * Check output of report for rubric grading method
      *
      * @covers ::rubric_ranges->get_data


### PR DESCRIPTION
## Problem
`btec::get_data()` never called `set_blindmarking()`, so the BTEC report leaked student identities (name, email, idnumber) on screen and in the Excel/CSV export even when the assignment used blind marking. The rubric, guide, rubref and rubric_ranges methods already obscure identities.

This has been broken since the BTEC method was first added. The v1.02 changelog claimed it was fixed, but no such code ever reached `btec.php` - that credit (Juan Segarra / issue #19) was actually for the active grading instances change.

## Fix
- Pass the `assign` object into `btec::get_data()` and run `set_blindmarking()` on the records, matching the other grading methods.
- Update the `btec.php` entry point call accordingly.

## Test
- Add `test_btec()` covering both the blind-marking and reveal-identities paths.
- Restores the BTEC grading fixture; compares against the real `{user}` record via the retained userid (no enrolment dependency).
- Skipped when the third-party `gradingform_btec` plugin is absent, so CI (which installs only this plugin) skips it cleanly rather than failing.

## Changelog
- New 1.05 entry for the real fix, plus a correction note against the misleading 1.02 mention.

## Verification
- `test_btec` passes locally (8 assertions); full file: 6 tests OK, 1 skipped.
- phpcs `moodle` standard: clean, no warnings.